### PR TITLE
migrate to Swift 5

### DIFF
--- a/ios/Classes/HomeViewController.swift
+++ b/ios/Classes/HomeViewController.swift
@@ -26,7 +26,7 @@ class HomeViewController: UIViewController, ImageScannerControllerDelegate {
         scanner.dismiss(animated: true)
         
 
-        var imagePath = saveImage(image:results.scannedImage)
+        let imagePath = saveImage(image:results.scannedImage)
      _result!(imagePath)
        self.dismiss(animated: true)   
     }
@@ -41,13 +41,13 @@ class HomeViewController: UIViewController, ImageScannerControllerDelegate {
     
 
     func saveImage(image: UIImage) -> String? {
-        guard let data = UIImageJPEGRepresentation(image, 1) ?? UIImagePNGRepresentation(image) else {
+        guard let data = image.jpegData(compressionQuality: 1) ?? image.pngData() else {
             return nil
         }
         guard let directory = try? FileManager.default.url(for: .documentDirectory, in: .userDomainMask, appropriateFor: nil, create: false) as NSURL else {
             return nil
         }
-        var fileName = randomString(length:10);
+        let fileName = randomString(length:10);
         let filePath: URL = directory.appendingPathComponent(fileName + ".png")!
         
 


### PR DESCRIPTION
The following error occurred during the build in Swift 5 because `UIImageJPEGRepresentation` and `UIImagePNGRepresentation` has been removed from Swift 4.2.

I fixed them and some warnings. Thanks.

```bash
Failed to build iOS app
Error output from Xcode build:
↳
    ** BUILD FAILED **


Xcode's output:
↳
    /Users/okady/workspace/y-okady/edge_detection/ios/Classes/HomeViewController.swift:29:13: warning: variable 'imagePath' was never mutated; consider changing to 'let' constant
            var imagePath = saveImage(image:results.scannedImage)
            ~~~ ^
            let
    /Users/okady/workspace/y-okady/edge_detection/ios/Classes/HomeViewController.swift:44:26: error: 'UIImageJPEGRepresentation' has been replaced by instance method
    'UIImage.jpegData(compressionQuality:)'
            guard let data = UIImageJPEGRepresentation(image, 1) ?? UIImagePNGRepresentation(image) else {
                             ^~~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~~~
                             image.jpegData                   compressionQuality: 
    UIKit.UIImageJPEGRepresentation:2:13: note: 'UIImageJPEGRepresentation' was obsoleted in Swift 3
    public func UIImageJPEGRepresentation(_ image: UIImage, _ compressionQuality: CGFloat) -> Data?
                ^
    /Users/okady/workspace/y-okady/edge_detection/ios/Classes/HomeViewController.swift:44:65: error: 'UIImagePNGRepresentation' has been replaced by instance method
    'UIImage.pngData()'
            guard let data = UIImageJPEGRepresentation(image, 1) ?? UIImagePNGRepresentation(image) else {
                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~ ~~~~~
                                                                    image.pngData            
    UIKit.UIImagePNGRepresentation:2:13: note: 'UIImagePNGRepresentation' was obsoleted in Swift 3
    public func UIImagePNGRepresentation(_ image: UIImage) -> Data?
                ^
    /Users/okady/workspace/y-okady/edge_detection/ios/Classes/HomeViewController.swift:50:13: warning: variable 'fileName' was never mutated; consider changing to 'let' constant
            var fileName = randomString(length:10);
            ~~~ ^
            let
    note: Using new build system
    note: Planning build
    note: Constructing build description

Could not build the application for the simulator.
```