### PR TITLE
Allows use both image_picker and edge_detection in the same project

### DIFF
--- a/android/src/main/kotlin/com/sample/edgedetection/EdgeDetectionDelegate.kt
+++ b/android/src/main/kotlin/com/sample/edgedetection/EdgeDetectionDelegate.kt
@@ -25,9 +25,10 @@ class EdgeDetectionDelegate(activity: Activity) : PluginRegistry.ActivityResultL
             } else if (resultCode == Activity.RESULT_CANCELED) {
                     finishWithSuccess(null)
             }
+            return true;
         }
 
-        return true;
+        return false;
     }
 
     fun OpenCameraActivity(call: MethodCall, result: MethodChannel.Result) {


### PR DESCRIPTION
this modification allows use both image_picker and edge_detection in the same project avoiding the "Image picker is already active" error, thanks of @fredriks for help about how fix it.