### PR TITLE
Replace crop menu button with FAB-like primary button

### DIFF
--- a/.idea/workspace.xml
+++ b/.idea/workspace.xml
@@ -1,45 +1,56 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="FileEditorManager">
-    <leaf>
-      <file leaf-file-name="edge_detection.dart" pinned="false" current-in-tab="true">
-        <entry file="file://$PROJECT_DIR$/lib/edge_detection.dart">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="0">
-              <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-            </state>
-          </provider>
-        </entry>
-      </file>
-      <file leaf-file-name="main.dart" pinned="false" current-in-tab="false">
-        <entry file="file://$PROJECT_DIR$/example/lib/main.dart">
-          <provider selected="true" editor-type-id="text-editor">
-            <state relative-caret-position="0">
-              <caret line="0" column="0" lean-forward="false" selection-start-line="0" selection-start-column="0" selection-end-line="0" selection-end-column="0" />
-            </state>
-          </provider>
-        </entry>
-      </file>
-    </leaf>
+  <component name="AutoImportSettings">
+    <option name="autoReloadType" value="NONE" />
   </component>
-  <component name="ToolWindowManager">
-    <editor active="true" />
-    <layout>
-      <window_info id="Project" active="true" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
-    </layout>
+  <component name="ChangeListManager">
+    <list default="true" id="f08b3923-f33b-4d39-b5f6-cea7d389432e" name="Default Changelist" comment="">
+      <change beforePath="$PROJECT_DIR$/edge_detection.iml" beforeDir="false" afterPath="$PROJECT_DIR$/edge_detection.iml" afterDir="false" />
+    </list>
+    <option name="SHOW_DIALOG" value="false" />
+    <option name="HIGHLIGHT_CONFLICTS" value="true" />
+    <option name="HIGHLIGHT_NON_ACTIVE_CHANGELIST" value="false" />
+    <option name="LAST_RESOLUTION" value="IGNORE" />
   </component>
+  <component name="ExecutionTargetManager" SELECTED_TARGET="device_and_snapshot_combo_box_target[/home/onli/.android/avd/Nexus_One_API_29.avd]" />
+  <component name="Git.Settings">
+    <option name="RECENT_GIT_ROOT_PATH" value="$PROJECT_DIR$" />
+  </component>
+  <component name="ProjectId" id="20ljkmskWJLGe2NakWfeESIRhXP" />
   <component name="ProjectView">
-    <navigator currentView="ProjectPane" proportions="" version="1">
-    </navigator>
+    <navigator currentView="ProjectPane" proportions="" version="1" />
     <panes>
       <pane id="ProjectPane">
         <option name="show-excluded-files" value="false" />
       </pane>
     </panes>
   </component>
+  <component name="ProjectViewState">
+    <option name="hideEmptyMiddlePackages" value="true" />
+    <option name="showLibraryContents" value="true" />
+  </component>
   <component name="PropertiesComponent">
-    <property name="last_opened_file_path" value="$PROJECT_DIR$" />
     <property name="dart.analysis.tool.window.force.activate" value="true" />
+    <property name="dart.analysis.tool.window.visible" value="false" />
+    <property name="last_opened_file_path" value="$PROJECT_DIR$/android" />
+    <property name="settings.editor.selected.configurable" value="preferences.language.Kotlin" />
     <property name="show.migrate.to.gradle.popup" value="false" />
+  </component>
+  <component name="SpellCheckerSettings" RuntimeDictionaries="0" Folders="0" CustomDictionaries="0" DefaultDictionary="application-level" UseSingleDictionary="true" transferred="true" />
+  <component name="TaskManager">
+    <task active="true" id="Default" summary="Default task">
+      <changelist id="f08b3923-f33b-4d39-b5f6-cea7d389432e" name="Default Changelist" comment="" />
+      <created>1636626215275</created>
+      <option name="number" value="Default" />
+      <option name="presentableId" value="Default" />
+      <updated>1636626215275</updated>
+    </task>
+    <servers />
+  </component>
+  <component name="ToolWindowManager">
+    <editor active="true" />
+    <layout>
+      <window_info id="Project" active="true" anchor="left" auto_hide="false" internal_type="DOCKED" type="DOCKED" visible="true" show_stripe_button="true" weight="0.25" sideWeight="0.5" order="0" side_tool="false" content_ui="combo" />
+    </layout>
   </component>
 </project>

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,6 @@
+#Thu Nov 11 11:29:31 CET 2021
 distributionBase=GRADLE_USER_HOME
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.0.2-bin.zip
 distributionPath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
+zipStoreBase=GRADLE_USER_HOME

--- a/android/src/main/kotlin/com/sample/edgedetection/crop/CropActivity.kt
+++ b/android/src/main/kotlin/com/sample/edgedetection/crop/CropActivity.kt
@@ -5,6 +5,7 @@ import android.content.Intent
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
+import android.view.View
 import android.widget.ImageView
 import androidx.appcompat.content.res.AppCompatResources
 import com.sample.edgedetection.R
@@ -34,6 +35,11 @@ class CropActivity : BaseActivity(), ICropView.Proxy {
 
     override fun initPresenter() {
         mPresenter = CropPresenter(this, this)
+        findViewById<ImageView>(R.id.crop).setOnClickListener {
+            Log.e(TAG, "Crop touched!")
+            mPresenter.crop()
+            changeMenuVisibility(true)
+        }
     }
 
     override fun getPaper(): ImageView = paper
@@ -50,10 +56,11 @@ class CropActivity : BaseActivity(), ICropView.Proxy {
         menu.findItem(R.id.rotation_image).isVisible = showMenuItems
 
         if (showMenuItems) {
-            menu.findItem(R.id.action_label)
-                    .setTitle(applicationContext.getString(R.string.done)).icon = AppCompatResources.getDrawable(
-                    applicationContext, R.drawable.ic_done
-            )
+            menu.findItem(R.id.action_label).isVisible = true
+            findViewById<ImageView>(R.id.crop).visibility = View.GONE
+        } else {
+            menu.findItem(R.id.action_label).isVisible = false
+            findViewById<ImageView>(R.id.crop).visibility = View.VISIBLE
         }
 
         return super.onCreateOptionsMenu(menu)
@@ -75,12 +82,6 @@ class CropActivity : BaseActivity(), ICropView.Proxy {
 
         if (item.itemId == R.id.action_label) {
             Log.e(TAG, item.title.toString())
-            if (item.title == applicationContext.getString(R.string.crop)) {
-                Log.e(TAG, "Crop touched!")
-                mPresenter.crop()
-                changeMenuVisibility(true)
-                return true
-            }
 
             if (item.title == applicationContext.getString(R.string.done)) {
                 Log.e(TAG, "Saved touched!")

--- a/android/src/main/res/layout/activity_crop.xml
+++ b/android/src/main/res/layout/activity_crop.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <ImageView
         android:id="@+id/picture_cropped"
@@ -64,5 +65,23 @@
         android:layout_marginBottom="20dp"
         android:tint="@color/colorPrimary"
         app:srcCompat="@drawable/ic_done_black_24dp" />-->
+
+    <RelativeLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_alignParentBottom="true"
+        android:padding="8dp">
+
+        <ImageView
+            android:id="@+id/crop"
+            android:layout_width="60dp"
+            android:layout_height="60dp"
+            android:layout_centerInParent="true"
+            android:background="@drawable/round_button"
+            android:padding="8dp"
+            app:srcCompat="@drawable/ic_crop"
+            app:tint="@android:color/darker_gray" />
+
+    </RelativeLayout>
 
 </RelativeLayout>

--- a/android/src/main/res/layout/activity_scan.xml
+++ b/android/src/main/res/layout/activity_scan.xml
@@ -29,8 +29,8 @@
             android:layout_centerInParent="true"
             android:background="@drawable/round_button"
             android:padding="8dp"
-            android:tint="@android:color/darker_gray"
-            app:srcCompat="@drawable/ic_menu_camera" />
+            app:srcCompat="@drawable/ic_menu_camera"
+            app:tint="@android:color/darker_gray" />
 
         <ImageView
             android:id="@+id/gallery"
@@ -40,8 +40,8 @@
             android:layout_centerVertical="true"
             android:background="@drawable/round_button"
             android:padding="8dp"
-            android:tint="@android:color/darker_gray"
-            app:srcCompat="@drawable/ic_menu_gallery" />
+            app:srcCompat="@drawable/ic_menu_gallery"
+            app:tint="@android:color/darker_gray" />
     </RelativeLayout>
 
 </RelativeLayout>

--- a/android/src/main/res/menu/crop_activity_menu.xml
+++ b/android/src/main/res/menu/crop_activity_menu.xml
@@ -2,8 +2,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
     <item
         android:id="@+id/action_label"
-        android:icon="@drawable/ic_crop"
-        android:title="@string/crop"
+        android:icon="@drawable/ic_done"
+        android:title="@string/done"
         app:showAsAction="always" />
 
     <item

--- a/edge_detection.iml
+++ b/edge_detection.iml
@@ -15,6 +15,5 @@
     <orderEntry type="sourceFolder" forTests="false" />
     <orderEntry type="library" name="Dart SDK" level="project" />
     <orderEntry type="library" name="Flutter Plugins" level="project" />
-    <orderEntry type="library" name="Dart Packages" level="project" />
   </component>
 </module>


### PR DESCRIPTION
As a reaction to https://github.com/sawankumarbundelkhandi/edge_detection/issues/67, this is a proposal to replace the crop menu button with a floating action button. 

I reused the one used as a camera button in the preceding view. Some small additional code changes were necessary to attach a click handler, to hide it after the crop, and because of the removal of the crop menu button (which at least simplifies the done button). It looks as this:

![Screenshot_1636638417](https://user-images.githubusercontent.com/71251334/141310377-8f9a19b6-8f9f-4cae-8a04-63651182c5fc.png)

![Screenshot_1636638423](https://user-images.githubusercontent.com/71251334/141310404-e5198d4a-b17e-47e9-9381-ffc4ae994f0c.png)


<hr />

Please note that the gradle version used so far was incompatible with my Android Studio version, please accept my apologies for that otherwise unwarranted change. The `android:tint` => `app:tint` change was also forced on me at that point. 

The upgrade(?) also changed the edge_detection.iml and the .idea/workspace.xml,  changes I can not properly judge apart from "it continued to work for me", but I hope you can properly evaluate them. 