### PR TITLE
#64 Replaced using android bar_height constants with direct view measuring

### DIFF
--- a/android/src/main/kotlin/com/sample/edgedetection/crop/CropActivity.kt
+++ b/android/src/main/kotlin/com/sample/edgedetection/crop/CropActivity.kt
@@ -2,6 +2,7 @@ package com.sample.edgedetection.crop
 
 import android.app.Activity
 import android.content.Intent
+import android.os.Bundle
 import android.util.Log
 import android.view.Menu
 import android.view.MenuItem
@@ -27,6 +28,14 @@ class CropActivity : BaseActivity(), ICropView.Proxy {
             System.gc()
             finish()
         }*/
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        paper.post {
+            //we have to initialize everything in post when the view has been drawn and we have the actual height and width of the whole view
+            mPresenter.onViewsReady(paper.width, paper.height)
+        }
     }
 
     override fun provideContentViewId(): Int = R.layout.activity_crop

--- a/android/src/main/kotlin/com/sample/edgedetection/crop/CropPresenter.kt
+++ b/android/src/main/kotlin/com/sample/edgedetection/crop/CropPresenter.kt
@@ -40,12 +40,12 @@ class CropPresenter(private val context: Context, private val iCropView: ICropVi
     private var rotateBitmap: Bitmap? = null
     private var rotateBitmapDegree: Int = -90
 
-    init {
+    fun onViewsReady(paperWidth : Int, paperHeight : Int) {
+        iCropView.getPaperRect().onCorners2Crop(corners, picture?.size(), paperWidth, paperHeight)
         val bitmap = Bitmap.createBitmap(picture?.width() ?: 1080, picture?.height()
                 ?: 1920, Bitmap.Config.ARGB_8888)
         Utils.matToBitmap(picture, bitmap, true)
         iCropView.getPaper().setImageBitmap(bitmap)
-        iCropView.getPaperRect().onCorners2Crop(corners, picture?.size())
     }
 
     private fun addImageToGalleryOldApi(filePath: String, context: Context) {

--- a/android/src/main/kotlin/com/sample/edgedetection/view/PaperRectangle.kt
+++ b/android/src/main/kotlin/com/sample/edgedetection/view/PaperRectangle.kt
@@ -81,7 +81,7 @@ class PaperRectangle : View {
         invalidate()
     }
 
-    fun onCorners2Crop(corners: Corners?, size: Size?) {
+    fun onCorners2Crop(corners: Corners?, size: Size?, paperWidth : Int, paperHeight : Int) {
         if (size == null) {
             return
         }
@@ -91,15 +91,8 @@ class PaperRectangle : View {
         tr = corners?.corners?.get(1) ?: Point(size.width * 0.9, size.height * 0.1)
         br = corners?.corners?.get(2) ?: Point(size.width * 0.9, size.height * 0.9)
         bl = corners?.corners?.get(3) ?: Point(size.width * 0.1, size.height * 0.9)
-        val displayMetrics = DisplayMetrics()
-        (context as Activity).windowManager.defaultDisplay.getMetrics(displayMetrics)
-        //exclude status bar height
-        val statusBarHeight = getStatusBarHeight(context)
-        //exclude navigation bar height
-        val navigationBarHeight = getNavigationBarHeight(context)
-        ratioX = size?.width?.div(displayMetrics.widthPixels) ?: 1.0
-        ratioY = size?.height?.div(displayMetrics.heightPixels - statusBarHeight - navigationBarHeight)
-                ?: 1.0
+        ratioX = size?.width?.div(paperWidth) ?: 1.0
+        ratioY = size?.height?.div(paperHeight) ?: 1.0
         resize()
         movePoints()
     }
@@ -189,21 +182,5 @@ class PaperRectangle : View {
         br.y = br.y.times(ratioY)
         bl.x = bl.x.times(ratioX)
         bl.y = bl.y.times(ratioY)
-    }
-
-    private fun getNavigationBarHeight(pContext: Context): Int {
-        val resources = pContext.resources
-        val resourceId = resources.getIdentifier("navigation_bar_height", "dimen", "android")
-        return if (resourceId > 0) {
-            resources.getDimensionPixelSize(resourceId)
-        } else 0
-    }
-
-    private fun getStatusBarHeight(pContext: Context): Int {
-        val resources = pContext.resources
-        val resourceId = resources.getIdentifier("status_bar_height", "dimen", "android")
-        return if (resourceId > 0) {
-            resources.getDimensionPixelSize(resourceId)
-        } else 0
     }
 }


### PR DESCRIPTION
The "navigation_bar_height" and "status_bar_height" android resources have wrong values on some devices. I took the liberty of measuring the paperView directly and got rid of using display metrics and subtracting the navigation/status bar heights.

Fixes https://github.com/sawankumarbundelkhandi/edge_detection/issues/64 