### PR TITLE
Avoid keep open scanScreen after pick from gallery on direct pickup

### DIFF
--- a/android/src/main/kotlin/com/sample/edgedetection/EdgeDetectionPlugin.kt
+++ b/android/src/main/kotlin/com/sample/edgedetection/EdgeDetectionPlugin.kt
@@ -102,7 +102,7 @@ class EdgeDetectionHandler : MethodCallHandler, PluginRegistry.ActivityResultLis
             return
         }
         val intent = Intent(Intent(getActivity()?.applicationContext, ScanActivity::class.java))
-        intent.putExtra("from_gallery", true)
+        intent.putExtra(ScanActivity.FROM_GALLERY, true)
         getActivity()?.startActivityForResult(intent, REQUEST_CODE)
     }
 

--- a/android/src/main/kotlin/com/sample/edgedetection/scan/ScanActivity.kt
+++ b/android/src/main/kotlin/com/sample/edgedetection/scan/ScanActivity.kt
@@ -40,6 +40,10 @@ class ScanActivity : BaseActivity(), IScanView.Proxy {
 
     override fun provideContentViewId(): Int = R.layout.activity_scan
 
+    companion object{
+        public const val FROM_GALLERY = "from_gallery"
+    }
+
     override fun initPresenter() {
         mPresenter = ScanPresenter(this, this)
     }
@@ -98,7 +102,7 @@ class ScanActivity : BaseActivity(), IScanView.Proxy {
             pickupFromGallery()
         };
 
-        if(intent.hasExtra("from_gallery") && intent.getBooleanExtra("from_gallery", false)){
+        if(intent.hasExtra(FROM_GALLERY) && intent.getBooleanExtra(FROM_GALLERY, false)){
             pickupFromGallery()
         }
     }
@@ -187,13 +191,21 @@ class ScanActivity : BaseActivity(), IScanView.Proxy {
                     setResult(Activity.RESULT_OK, Intent().putExtra(SCANNED_RESULT, path))
                     finish()
                 }
+            }else{
+                if(intent.hasExtra(FROM_GALLERY) && intent.getBooleanExtra(FROM_GALLERY, false))
+                    finish()
             }
         }
 
-        if (requestCode == 1 && resultCode == Activity.RESULT_OK) {
-            val uri: Uri = data!!.data!!
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                onImageSelected(uri)
+        if (requestCode == 1) {
+            if (resultCode == Activity.RESULT_OK) {
+                val uri: Uri = data!!.data!!
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                    onImageSelected(uri)
+                }
+            }else{
+                if(intent.hasExtra(FROM_GALLERY) && intent.getBooleanExtra(FROM_GALLERY, false))
+                    finish()
             }
         }
     }

--- a/ios/Classes/SwiftEdgeDetectionPlugin.swift
+++ b/ios/Classes/SwiftEdgeDetectionPlugin.swift
@@ -26,8 +26,7 @@ public class SwiftEdgeDetectionPlugin: NSObject, FlutterPlugin, UIApplicationDel
             if let viewController = UIApplication.shared.delegate?.window??.rootViewController as? FlutterViewController {
                 let destinationViewController = HomeViewController()
                 destinationViewController._result = result
-                destinationViewController.selectPhoto()
-                viewController.present(destinationViewController,animated: true,completion: nil);
+                destinationViewController.selectPhoto();
             }
         }
     }


### PR DESCRIPTION
As normal procedure, when pickup from gallery direct action is called, and canceled, should go to main screen instead to scan activity

tested on: 
Mi 8 Lite (platina) with Android 11 MiUI 12.5
iOS simlator iPhone SE 3rd gen with iOS 15.4